### PR TITLE
unpacker: Add TargetLayerDigestLabel label to unpack flow

### DIFF
--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	labelSnapshotRef = "containerd.io/snapshot.ref"
-	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest",
+	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest"
 	unpackSpanPrefix = "pkg.unpack.unpacker"
 )
 

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -49,6 +49,7 @@ import (
 
 const (
 	labelSnapshotRef = "containerd.io/snapshot.ref"
+	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest",
 	unpackSpanPrefix = "pkg.unpack.unpacker"
 )
 
@@ -308,6 +309,7 @@ func (u *Unpacker) unpack(
 			snapshotLabels = make(map[string]string)
 		}
 		snapshotLabels[labelSnapshotRef] = chainID
+		snapshotLabels[targetLayerDigestLabel] = desc.Digest.String()
 
 		var (
 			key    string


### PR DESCRIPTION
Add the label to the flow when image is pulled and unpacked for the sandbox container using unpacker.Unpack() from PullImage().
The flow is triggered when a container is created.
Not having this label, the image pull fails as the Prepare() step of tardev snapshotter fails as it tries to read a filepath which doesn't exist yet (goes to else block in absence of the label). [Ref](https://github.com/microsoft/kata-containers/blob/2795dae5e99bd918b7b8d0a9643e9a857e95813d/src/tardev-snapshotter/src/snapshotter.rs#L390)
The previous commit addresses addition of the same label in only the image.Unpack() flow.